### PR TITLE
HW6, Лазарева

### DIFF
--- a/project/cf_grammar.py
+++ b/project/cf_grammar.py
@@ -1,0 +1,49 @@
+from pyformlang.cfg import CFG, Terminal
+
+
+def cfg_to_weak_normal_from(grammar: CFG) -> CFG:
+    """
+    Turns the grammar into a grammar in a weak Chomsky form
+
+    Parameters:
+        grammar: context-free grammar
+
+    Returns:
+        context-free grammar in a weak Chomsky form
+    """
+    initial_grammar_rules = grammar.productions
+    initial_grammar_start_symbol = grammar.start_symbol
+
+    without_epsilons = grammar.remove_epsilon().productions
+    epsilon_rules = set(initial_grammar_rules) - set(without_epsilons)  # set of epsilon rules
+
+    # add rules with terminals on the right side
+    start_terminal_right = set()
+    for production in initial_grammar_rules:
+        if initial_grammar_start_symbol in production.body and len(production.body) == 2:
+            for symb in production.body:
+                if not isinstance(symb, Terminal):
+                    start_terminal_right.add(production)
+
+    rules = start_terminal_right.union(epsilon_rules)
+    normal_form = grammar.to_normal_form()
+    return CFG(
+        variables=normal_form.variables,
+        terminals=normal_form.terminals,
+        start_symbol=initial_grammar_start_symbol,
+        productions=rules.union(normal_form.productions)
+    )
+
+
+def text_grammar_to_weak_normal_form(file: str) -> CFG:
+    """
+    Creates context-free grammar with the rules from a file.
+
+    Parameters:
+        file: name of a file to read from
+
+    Return:
+        Context-free grammar with the rules from a file
+    """
+    with open(file) as f:
+        return CFG.from_text(f.read())

--- a/project/cf_grammar.py
+++ b/project/cf_grammar.py
@@ -11,27 +11,15 @@ def cfg_to_weak_normal_from(grammar: CFG) -> CFG:
     Returns:
         context-free grammar in a weak Chomsky form
     """
-    initial_grammar_rules = grammar.productions
-    initial_grammar_start_symbol = grammar.start_symbol
+    grammar_m = grammar.eliminate_unit_productions().remove_useless_symbols()
+    dec = grammar_m._get_productions_with_only_single_terminals()
+    new_prod = grammar_m._decompose_productions(dec)
 
-    without_epsilons = grammar.remove_epsilon().productions
-    epsilon_rules = set(initial_grammar_rules) - set(without_epsilons)  # set of epsilon rules
-
-    # add rules with terminals on the right side
-    start_terminal_right = set()
-    for production in initial_grammar_rules:
-        if initial_grammar_start_symbol in production.body and len(production.body) == 2:
-            for symb in production.body:
-                if not isinstance(symb, Terminal):
-                    start_terminal_right.add(production)
-
-    rules = start_terminal_right.union(epsilon_rules)
-    normal_form = grammar.to_normal_form()
     return CFG(
-        variables=normal_form.variables,
-        terminals=normal_form.terminals,
-        start_symbol=initial_grammar_start_symbol,
-        productions=rules.union(normal_form.productions)
+        variables=grammar_m.variables,
+        terminals=grammar_m.terminals,
+        start_symbol=grammar_m.start_symbol,
+        productions=new_prod
     )
 
 

--- a/tests/tests_cfg.py
+++ b/tests/tests_cfg.py
@@ -1,0 +1,33 @@
+import tempfile
+from pyformlang.cfg import CFG, Variable, Production, Epsilon, Terminal
+
+from project.cf_grammar import (
+    cfg_to_weak_normal_from,
+    text_grammar_to_weak_normal_form
+)
+
+
+def test_cfg_to_weak_nf():
+    with tempfile.NamedTemporaryFile(mode='r+') as file:
+        file.write('S -> S A\n')
+        file.write('S -> a S\n')
+        file.write('A -> epsilon\n')
+        # file.write('B -> b')
+        file.seek(0)
+        grammar = text_grammar_to_weak_normal_form(file.name)
+        grammar = cfg_to_weak_normal_from(grammar)
+
+    production1 = Production(head=Variable('S'), body=[Variable('S'), Variable('A')])
+    production2 = Production(head=Variable('S'), body=[Variable('a'), Variable('S')])
+    production3 = Production(head=Variable('A'), body=[Epsilon()])
+    # production4 = Production(head=Variable('B'), body=[Terminal('b')])
+
+    assert grammar.start_symbol.value == 'S'
+    assert production1 in grammar.productions
+    assert production2 not in grammar.productions
+    assert production3 in grammar.productions
+    # assert production4 in grammar.productions
+
+
+
+

--- a/tests/tests_cfg.py
+++ b/tests/tests_cfg.py
@@ -9,25 +9,25 @@ from project.cf_grammar import (
 
 def test_cfg_to_weak_nf():
     with tempfile.NamedTemporaryFile(mode='r+') as file:
-        file.write('S -> S A\n')
-        file.write('S -> a S\n')
-        file.write('A -> epsilon\n')
-        # file.write('B -> b')
+        file.write('S -> A B C\n')
+        file.write('A -> a \n')
+        file.write('B -> b \n')
+        file.write('C -> c')
         file.seek(0)
         grammar = text_grammar_to_weak_normal_form(file.name)
         grammar = cfg_to_weak_normal_from(grammar)
 
-    production1 = Production(head=Variable('S'), body=[Variable('S'), Variable('A')])
-    production2 = Production(head=Variable('S'), body=[Variable('a'), Variable('S')])
-    production3 = Production(head=Variable('A'), body=[Epsilon()])
-    # production4 = Production(head=Variable('B'), body=[Terminal('b')])
+    res = CFG.from_text(
+        """
+        B -> b
+        A -> a
+        C -> c
+        S -> A C#CNF#1
+        C#CNF#1 -> B C"""
+    )
 
     assert grammar.start_symbol.value == 'S'
-    assert production1 in grammar.productions
-    assert production2 not in grammar.productions
-    assert production3 in grammar.productions
-    # assert production4 in grammar.productions
-
+    assert set(grammar.productions) == set(res.productions)
 
 
 


### PR DESCRIPTION
В тестах есть закомментированное правило из нетерминала в терминал. Почему-то при приведении грамматики к НФХ это правило выбрасывается, его нет в аттрибуте `productions`. Но этого отличия между ОНФХ и НФХ не указано в `READ.me`. Почему `to_normal_form` выбрасывает продукции вида `B- -> Terminal(b)`?